### PR TITLE
FIX reservationテーブルの関連付けでカラム名ではなく関連名を書くように修正

### DIFF
--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -1,4 +1,4 @@
 class Reservation < ApplicationRecord
-  belongs_to :court_id
-  belongs_to :user_id
+  belongs_to :court
+  belongs_to :user
 end


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示：このプルリクエストをレビューしてコメントする際には日本語でお願いします。 -->

## やったこと
題名の通り。